### PR TITLE
Feature/prefers native remote

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Cosmos (15.0.0)
   - Extra/UIKit (1.1.1)
   - Jelly (1.2.4)
-  - StarsKit (0.1.0):
+  - StarsKit (0.3.0):
     - Cosmos (~> 15.0)
     - Extra/UIKit (~> 1.1)
     - Jelly (~> 1.2)
@@ -30,7 +30,7 @@ SPEC CHECKSUMS:
   Cosmos: a6dbd3d0baa0cc8f51f8598f7508d5a09d0a9ade
   Extra: 7c4e5aff4904ecdadc615f63d4c2f0c20910c028
   Jelly: 70e542dd201460211f0f20042bc2c2d31ae239a1
-  StarsKit: ce5c6f258f8ca4d87b7f88afcf4287b15b2bd09a
+  StarsKit: b9b0cbe6bfb9dee0c2c65ff3ae93a2d388dd52fb
   SwiftDate: 7b56d42a221f582047287deb256b23fc5ed49a60
   SwiftLint: 3207c1faa2240bf8973b191820a116113cd11073
 

--- a/Example/StarsKit/Base.lproj/Main.storyboard
+++ b/Example/StarsKit/Base.lproj/Main.storyboard
@@ -39,7 +39,7 @@
                                 <rect key="frame" x="20" y="0.0" width="794" height="1048"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dCa-EC-F5e">
-                                        <rect key="frame" x="0.0" y="0.0" width="794" height="84"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="794" height="97.5"/>
                                         <state key="normal" title="Show Rating">
                                             <color key="titleColor" red="1" green="0.068409402580000001" blue="0.081648422829999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </state>
@@ -47,34 +47,17 @@
                                             <action selector="didTapShowRatingButton:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="L6J-ok-4wz"/>
                                         </connections>
                                     </button>
-                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="q8f-iY-N49">
-                                        <rect key="frame" x="0.0" y="104" width="794" height="88"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Use native rating:" textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4dY-LA-p9U">
-                                                <rect key="frame" x="0.0" y="34" width="387" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="272-RY-gGu">
-                                                <rect key="frame" x="407" y="28.5" width="389" height="31"/>
-                                                <connections>
-                                                    <action selector="didSwitchNativeRating:" destination="vXZ-lx-hvc" eventType="valueChanged" id="OaH-1Q-L4D"/>
-                                                </connections>
-                                            </switch>
-                                        </subviews>
-                                    </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="rg0-u2-oFd">
-                                        <rect key="frame" x="0.0" y="212" width="794" height="88.5"/>
+                                        <rect key="frame" x="0.0" y="117.5" width="794" height="102"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Use custom image:" textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kde-jF-H6h">
-                                                <rect key="frame" x="0.0" y="34" width="387" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="40.5" width="387" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="F8W-R9-YHy">
-                                                <rect key="frame" x="407" y="28.5" width="389" height="31"/>
+                                                <rect key="frame" x="407" y="35.5" width="389" height="31"/>
                                                 <connections>
                                                     <action selector="didSwitchCustomImageMode:" destination="vXZ-lx-hvc" eventType="valueChanged" id="AwH-HS-9bZ"/>
                                                 </connections>
@@ -82,7 +65,7 @@
                                         </subviews>
                                     </stackView>
                                     <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="MHE-N0-EnE">
-                                        <rect key="frame" x="0.0" y="320.5" width="794" height="79"/>
+                                        <rect key="frame" x="0.0" y="239.5" width="794" height="92"/>
                                         <segments>
                                             <segment title="Default transition"/>
                                             <segment title="Bottom transition"/>
@@ -93,16 +76,16 @@
                                         </connections>
                                     </segmentedControl>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="OKp-X8-2NP">
-                                        <rect key="frame" x="0.0" y="418.5" width="794" height="88.5"/>
+                                        <rect key="frame" x="0.0" y="350.5" width="794" height="102"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Use localization strings (or config)" textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qf2-bu-ZLW">
-                                                <rect key="frame" x="0.0" y="34" width="387" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="40.5" width="387" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="zt9-S1-bpM">
-                                                <rect key="frame" x="407" y="28.5" width="389" height="31"/>
+                                                <rect key="frame" x="407" y="35.5" width="389" height="31"/>
                                                 <connections>
                                                     <action selector="didSwitchLocalizable:" destination="vXZ-lx-hvc" eventType="valueChanged" id="gVC-VH-gQU"/>
                                                 </connections>
@@ -110,16 +93,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="0Ha-9J-PVc">
-                                        <rect key="frame" x="0.0" y="527" width="794" height="88"/>
+                                        <rect key="frame" x="0.0" y="472.5" width="794" height="102.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Use session interval checking " textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wA1-kB-ab6">
-                                                <rect key="frame" x="0.0" y="33.5" width="387" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="41" width="387" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="gZR-S5-Q6W">
-                                                <rect key="frame" x="407" y="28.5" width="389" height="31"/>
+                                                <rect key="frame" x="407" y="35.5" width="389" height="31"/>
                                                 <connections>
                                                     <action selector="didSwitchSessionIntervalCheck:" destination="vXZ-lx-hvc" eventType="valueChanged" id="xwG-f5-Nb3"/>
                                                 </connections>
@@ -127,22 +110,22 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="7fh-M0-8QV">
-                                        <rect key="frame" x="0.0" y="635" width="794" height="57.5"/>
+                                        <rect key="frame" x="0.0" y="595" width="794" height="66.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="k17-d9-qYT">
-                                                <rect key="frame" x="0.0" y="0.0" width="260.5" height="57.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="260.5" height="66.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Wv-MX-WL8">
-                                                <rect key="frame" x="280.5" y="0.0" width="260" height="57.5"/>
+                                                <rect key="frame" x="280.5" y="0.0" width="260" height="66.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SAx-st-Quq">
-                                                <rect key="frame" x="560.5" y="0.0" width="233.5" height="57.5"/>
+                                                <rect key="frame" x="560.5" y="0.0" width="233.5" height="66.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -150,24 +133,24 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="fOM-id-feg">
-                                        <rect key="frame" x="0.0" y="712.5" width="794" height="335.5"/>
+                                        <rect key="frame" x="0.0" y="681.5" width="794" height="366.5"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ylr-HF-jRR">
-                                                <rect key="frame" x="0.0" y="152.5" width="216.5" height="30"/>
+                                                <rect key="frame" x="0.0" y="168" width="216.5" height="30"/>
                                                 <state key="normal" title="Session++"/>
                                                 <connections>
                                                     <action selector="didTapIncrementSession:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="6qE-nf-oEn"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sgx-kF-cKc">
-                                                <rect key="frame" x="236.5" y="152.5" width="177.5" height="30"/>
+                                                <rect key="frame" x="236.5" y="168" width="177.5" height="30"/>
                                                 <state key="normal" title="Crash++"/>
                                                 <connections>
                                                     <action selector="didTapIncrementCrash:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="epD-0a-e0D"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hPU-2k-QMX">
-                                                <rect key="frame" x="434" y="152.5" width="360" height="30"/>
+                                                <rect key="frame" x="434" y="168" width="360" height="30"/>
                                                 <state key="normal" title="Reset context"/>
                                                 <connections>
                                                     <action selector="didTapResetMetrics:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="IOf-6X-GiG"/>

--- a/Example/StarsKit/Resources/config.json
+++ b/Example/StarsKit/Resources/config.json
@@ -1,5 +1,6 @@
 {
     "disabled": false,
+    "prefersNativeRating": false,
     "displaySessionCount": 3,
     "mainTitle": "Your opinion interests us :)",
     "mainText": "Do you like the app StarsKit?",

--- a/Example/StarsKit/ViewController.swift
+++ b/Example/StarsKit/ViewController.swift
@@ -114,10 +114,6 @@ class ViewController: UIViewController {
     StarsKit.shared.customImageMode = sender.isOn
   }
   
-  @IBAction func didSwitchNativeRating(_ sender: UISwitch) {
-    StarsKit.shared.priorityUseNativeRate = sender.isOn
-  }
-  
   @IBAction func didSwitchLocalizable(_ sender: UISwitch) {
     StarsKit.shared.localLocalizableStringsEnabled = sender.isOn
   }

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ JSON StarsKit configuration example:
 ``` json
 {
     "disabled": false,
+    "prefersNativeRating": false,
     "displaySessionCount": 3,
     "mainTitle": "Your opinion interests us :)",
     "mainText": "Do you like the app StarsKit?",
@@ -174,7 +175,6 @@ You can also decide of:
 
 - **`validateRatingButtonEnable`**: disable or enable the submit step rating. If disabled, the rate will be instantly submited after user touch.
 - **`useDefaultBehavior`**: disable the default StarsKit display checking behavior and implement your own in the `StarsKitDelegate`
-- **`priorityUseNativeRate`**: enable the native rating in iOS 10.3+, if not available, it will use the StarsKit screens 👌🏼
 - **`useSessionSpaceChecking`**: disable/enable the default checking of time elapsed between sessions. If enabled, when you update the session count, **the session count will only be updated if the time between session is completely elapsed.**. In others words, the user not enough uses the app for incrementing the session count. The same if you want to increment the session the same day than the last before, it will not be set.
 - **`localLocalizableStringsEnabled`**: enable the localization titles instead of configuration one. It will use the default StarKit strings. If you override them in your app localizable strings (with the same key), it will take them 😎.
 

--- a/StarsKit.podspec
+++ b/StarsKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'StarsKit'
-  s.version          = '0.2.0'
+  s.version          = '0.3.0'
   s.summary          = 'StarsKit is a Swift library to simplify, customize and configure your app rating workflow.'
 
   s.homepage         = 'https://github.com/smartnsoft/StarsKit'

--- a/StarsKit/Classes/Logic/StarsKit.swift
+++ b/StarsKit/Classes/Logic/StarsKit.swift
@@ -44,9 +44,6 @@ public class StarsKit {
   /// Defines if StarsKit will apply its own behavior process or if you want to apply yours.
   public var useDefaultBehavior = true
   
-  /// Defines if you want to enable the StoreKit Rating Controller (from iOS 10.3 only).
-  public var priorityUseNativeRate = false
-  
   /// Defines if you want to enable the time condition space between to sessions.
   ///
   /// If the session set is to close in the given period time, the session number will not be set.
@@ -97,7 +94,7 @@ public class StarsKit {
       || (self.useDefaultBehavior && StarsKitChecker.needDisplayRateScreen(for: self))
       || (self.delegate != nil && self.delegate?.needCustomDisplayRateScreen() == true) {
       
-      if self.priorityUseNativeRate {
+      if configuration.prefersNativeRating {
         //Use 10.3 + native app rating
         if #available(iOS 10.3, *) {
           SKStoreReviewController.requestReview()
@@ -136,6 +133,7 @@ public class StarsKit {
     self.configuration.daysBeforeAskingAgain = 0
     self.configuration.daysWithoutCrash = 0
     self.configuration.disabled = false
+    self.configuration.prefersNativeRating = false
     self.configuration.displaySessionCount = 0
     self.configuration.maxDaysBetweenSession = 0
     self.configuration.maxNumberOfReminder = 0

--- a/StarsKit/Classes/Logic/StarsKitConfigProperties.swift
+++ b/StarsKit/Classes/Logic/StarsKitConfigProperties.swift
@@ -27,6 +27,7 @@ import Foundation
 /// Those keys will be used in the configuration update via a dictionnary.
 internal enum StarsKitConfigProperties: String {
   case disabled
+  case prefersNativeRating
   case displaySessionCount
   case positiveStarsLimit
   case daysWithoutCrash
@@ -36,6 +37,9 @@ internal enum StarsKitConfigProperties: String {
   case emailSupport
   case emailObject
   case emailHeaderContent
+
+  static let allBoolValues: [StarsKitConfigProperties] = [.disabled,
+                                                          .prefersNativeRating]
   
   static let allIntValues: [StarsKitConfigProperties] = [.displaySessionCount,
                                                           .positiveStarsLimit,

--- a/StarsKit/Classes/Logic/StarsKitConfiguration.swift
+++ b/StarsKit/Classes/Logic/StarsKitConfiguration.swift
@@ -35,6 +35,15 @@ public final class StarsKitConfiguration {
       UserDefaults.standard.set(newValue, forKey: StarsKitConfigProperties.disabled.userDefaultsKey)
     }
   }
+
+  public internal(set) var prefersNativeRating: Bool {
+    get {
+      return UserDefaults.standard.bool(forKey: StarsKitConfigProperties.prefersNativeRating.userDefaultsKey)
+    }
+    set {
+      UserDefaults.standard.set(newValue, forKey: StarsKitConfigProperties.prefersNativeRating.userDefaultsKey)
+    }
+  }
   
   public internal(set) var displaySessionCount: Int {
     get {
@@ -132,13 +141,13 @@ public final class StarsKitConfiguration {
   ///
   /// - Parameter config: Key-Value dictionnary with StarsKitProperties & StarsKitLocalizableKeys keys
   func update(with config: [String: Any?]) {
-    
+
     self.updateMetrics(from: config)
     self.updateLocalizables(from: config)
   }
   
   // MARK: Private methods
-  
+
   /// Update localizable UserDefaults strings
   ///
   /// - Parameter config: Key-Value dictionnary with StarsKitLocalizableKeys keys
@@ -154,10 +163,13 @@ public final class StarsKitConfiguration {
   ///
   /// - Parameter config: Key-Value dictionnary with StarsKitProperties keys
   private func updateMetrics(from config: [String: Any?]) {
-    if let isDisabled = config[StarsKitConfigProperties.disabled.rawValue] as? Bool {
-      self.disabled = isDisabled
+
+    StarsKitConfigProperties.allBoolValues.forEach { (property) in
+      if let boolValue = config[property.rawValue] as? Bool {
+        UserDefaults.standard.setValue(boolValue, forKey: property.userDefaultsKey)
+      }
     }
-    
+
     StarsKitConfigProperties.allIntValues.forEach { (property) in
       if let intValue = config[property.rawValue] as? Int {
         self.updateInt(value: intValue, for: property)


### PR DESCRIPTION
The property to determine whether to use the native rating popUp or the custom one is now part of the Configuration object. 
This means it's no longer directly settable using `StarsKit.shared.priorityUseNativeRate`, instead it has to be an entry of the dictionary passed to `StarsKit.shared.updateConfig()`. 
It makes the property settable remotely.